### PR TITLE
Update README to include Debian 11 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,21 @@ cd virt-backup
 ruby virt-backup.rb --help
 ```
 
+> To install Ruby 2.7 on **Debian 11 (Bullseye)** you can follow the steps contained in the 
+[install_ruby_2.7_Debian_11.md](docs/install_ruby_2.7_Debian_11.md) document. 
+
 ---
 
 #### Installation test result
 
 | Distro         | Test Result |
 | -------------- | ----------- |
-| `Ubuntu 16.04` | ✔️           |
-| `Ubuntu 18.04` | ✔️           |
-| `Centos 7`     | ✔️           |
+| `Ubuntu 16.04` | 🟢          |
+| `Ubuntu 18.04` | 🟢          |
+| `Centos 7`     | 🟢          |
+| `Debian 11`    | 🟠          |
 
+**Note for Debian users:** backups using the `--with-snapshots`, or `-s` option will succeed but restoring the backup fails. [See this issue](https://github.com/eslam-gomaa/virt-backup/issues/4) for more details on the matter. For now, make sure you omit the with snapshots option flag when creating a backup. Everything else works perfectly.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ruby virt-backup.rb --backup \
 
 
 
-## Example screenshoots
+## Example screenshots
 
 
 
@@ -142,7 +142,7 @@ ruby /root/virt-backup/virt-backup.rb \
 ruby /root/virt-backup/virt-backup.rb \
   --restore \
   --with-snapshots \
-  --backup-file /var/lib/libvirt/images/backup-11/snap23.zip 
+  --backup-file /var/lib/libvirt/images/backup-11/snap23.zip \
   --restore-dir /var/lib/libvirt/images
 ```
 


### PR DESCRIPTION
Assuming you merge #5 then the changes in this document include Debian 11 specific instructions.